### PR TITLE
3. [DONE] Fix bug: properly show external iframe tile to the right if showingBar.

### DIFF
--- a/src/components/ExternalTile.js
+++ b/src/components/ExternalTile.js
@@ -78,7 +78,7 @@ class ExternalTileComponent extends Component {
           showingBar,
           fullLayoutSidebarWidth
         )
-      : this.renderIframe(title, url, showingBar);
+      : this.renderIframe(title, url, showingBar, fullLayoutSidebarWidth);
   }
 
   renderIframe(title, url, showingBar, fullLayoutSidebarWidth) {


### PR DESCRIPTION
In production, external iframe tiles are shown behind the sidebar on the left

https://logic.lizard.net/dashboard/full/4

This is because the fullLayoutSidebarWidth is not properly given to renderIframe