### PR TITLE
Fixes for merging dashboard landing page to tile dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.0.52"></a>
+## [0.0.52](https://github.com/nens/lizard-tile-dashboard/compare/v0.0.51...v0.0.52) (2020-02-04)
+
+
+
 <a name="0.0.51"></a>
 ## [0.0.51](https://github.com/nens/lizard-tile-dashboard/compare/v0.0.50...v0.0.51) (2020-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.0.51"></a>
+## [0.0.51](https://github.com/nens/lizard-tile-dashboard/compare/v0.0.50...v0.0.51) (2020-02-04)
+
+
+
 <a name="0.0.50"></a>
 ## [0.0.50](https://github.com/nens/lizard-tile-dashboard/compare/v0.0.49...v0.0.50) (2020-02-04)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lizard-tile-dashboard",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "repository": {
     "type": "git",
     "name": "nens/lizard-tile-dashboard",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lizard-tile-dashboard",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "repository": {
     "type": "git",
     "name": "nens/lizard-tile-dashboard",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import LandingPage from "./components/LandingPage";
 import GridLayout from "./components/GridLayout";
 import FullLayout from "./components/FullLayout";
 import { connect } from "react-redux";
-import { Route, RouteComponentProps, withRouter } from "react-router-dom";
+import { Route, RouteComponentProps, withRouter, Redirect } from "react-router-dom";
 
 import { fetchAlarms, setNowAction } from "./actions";
 import { getNow } from "./reducers";
@@ -40,9 +40,10 @@ class App extends Component<AppProps, {}> {
   render() {
     return (
       <div className={styles.App}>
-        <Route exact path="/" component={LandingPage} />
-        <Route exact path="/:dashboardName" component={GridLayout} />
-        <Route exact path="/:dashboardName/full/:id" component={FullLayout} />
+        <Route exact path='/' render={() => <Redirect to='/dashboards' />} />
+        <Route exact path="/dashboards" component={LandingPage} />
+        <Route exact path="/dashboards/:dashboardName" component={GridLayout} />
+        <Route exact path="/dashboards/:dashboardName/full/:id" component={FullLayout} />
       </div>
     );
   }

--- a/src/LoginOrApp.js
+++ b/src/LoginOrApp.js
@@ -23,13 +23,15 @@ class LoginOrAppComponent extends Component {
   }
 
   getDashboardName = () => {
-    // URL paths are either "/dashboards/" or "/dashboards/dashboardName/" or "/dashboards/dashboardName/full/id/"
-    const urlPostDashboards = window.location.pathname.split("/dashboards/")[1];
+    // // URL paths are either "/dashboards/" or "/dashboards/dashboardName/" or "/dashboards/dashboardName/full/id/"
+    const dashboardName = window.location.pathname.split("/").includes('dashboards') ? (
+      window.location.pathname.split("/")[2]
+    ) : (
+      // Only happen in dev when the URL does not include dashboards
+      window.location.pathname.split("/")[1]
+    );
 
-    // if there is no /dashboards/ in the url, should only happen in dev
-    if (!urlPostDashboards) return window.location.pathname.split("/")[1];
-
-    return urlPostDashboards.split("/")[0];
+    return dashboardName;
   }
 
   hasBootstrap() {

--- a/src/LoginOrApp.js
+++ b/src/LoginOrApp.js
@@ -23,15 +23,8 @@ class LoginOrAppComponent extends Component {
   }
 
   getDashboardName = () => {
-    // // URL paths are either "/dashboards/" or "/dashboards/dashboardName/" or "/dashboards/dashboardName/full/id/"
-    const dashboardName = window.location.pathname.split("/").includes('dashboards') ? (
-      window.location.pathname.split("/")[2]
-    ) : (
-      // Only happen in dev when the URL does not include dashboards
-      window.location.pathname.split("/")[1]
-    );
-
-    return dashboardName;
+    // URL paths are either "/dashboards/" or "/dashboards/dashboardName/" or "/dashboards/dashboardName/full/id/"
+    return window.location.pathname.split("/")[2];
   }
 
   hasBootstrap() {

--- a/src/components/FullLayout.js
+++ b/src/components/FullLayout.js
@@ -265,7 +265,7 @@ class FullLayout extends Component {
               height: FULL_LAYOUT_HEADER_HEIGHT + "px"
             }}
           >
-            <NavLink to={`/${dashboardName}`}>
+            <NavLink to={`/dashboards/${dashboardName}`}>
               <div className={styles.BackButton}>
                 <i className="material-icons" style={fgColor? { color: fgColor }: {}}>
                   arrow_back

--- a/src/components/FullLayout.js
+++ b/src/components/FullLayout.js
@@ -234,7 +234,7 @@ class FullLayout extends Component {
                   const shortTitle = tile.shortTitle || tile.title;
 
                   return (
-                    <NavLink to={`/${dashboardName}/full/${tile.id}`} key={i}>
+                    <NavLink to={`/dashboards/${dashboardName}/full/${tile.id}`} key={i}>
                       <div
                         className={styles.SidebarItemWrapper}
                         title={shortTitle}

--- a/src/components/GridLayout.js
+++ b/src/components/GridLayout.js
@@ -231,7 +231,7 @@ class GridLayout extends Component {
             {...this.props}
             title={shortTitle}
             backgroundColor={"#FFFFFF"}
-            onClick={() => history.push(`/${dashboardName}/full/${tile.id}`)}
+            onClick={() => history.push(`/dashboards/${dashboardName}/full/${tile.id}`)}
           >
             <ExternalTile isFull={false} tile={tile} source={"GridLayout"} />
           </Tile>
@@ -243,7 +243,7 @@ class GridLayout extends Component {
               <Tile
                 {...this.props}
                 title={shortTitle}
-                onClick={() => history.push(`/${dashboardName}/full/${tile.id}`)}
+                onClick={() => history.push(`/dashboards/${dashboardName}/full/${tile.id}`)}
               >
                 <Map isFull={false} bbox={tile.bbox} tile={tile} />
               </Tile>
@@ -253,7 +253,7 @@ class GridLayout extends Component {
               <Tile
                 {...this.props}
                 title={shortTitle}
-                onClick={() => history.push(`/${dashboardName}/full/${tile.id}`)}
+                onClick={() => history.push(`/dashboards/${dashboardName}/full/${tile.id}`)}
               >
                 <TimeseriesTile
                   isFull={false}
@@ -268,7 +268,7 @@ class GridLayout extends Component {
               <Tile
                 {...this.props}
                 title={shortTitle}
-                onClick={() => history.push(`/${dashboardName}/full/${tile.id}`)}
+                onClick={() => history.push(`/dashboards/${dashboardName}/full/${tile.id}`)}
               >
                 <StatisticsTile
                   alarms={this.props.alarms}
@@ -282,7 +282,7 @@ class GridLayout extends Component {
                 {...this.props}
                 title={shortTitle}
                 backgroundColor={"#FFFFFF"}
-                onClick={() => history.push(`/${dashboardName}/full/${tile.id}`)}
+                onClick={() => history.push(`/dashboards/${dashboardName}/full/${tile.id}`)}
               >
                 <ExternalTile
                   isFull={false}
@@ -326,7 +326,7 @@ class GridLayout extends Component {
               </div>
               <a
                 className={styles.BackButton}
-                href="/"
+                href="/dashboards"
               >
                 {width > maxMobileWidth ? (
                   <span><i className="material-icons">arrow_back</i>&nbsp;&nbsp;Back</span>

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -124,7 +124,7 @@ class LandingPage extends Component {
                 <a 
                   className={styles.Dashboard}
                   key={i}
-                  href={`/${dashboard.slug.client_slug}`}
+                  href={`/dashboards/${dashboard.slug.client_slug}`}
                 >
                   <div className={styles.DashboardLogo}>
                     {dashboard.logo ? <img src={this.getImageUrl(dashboard.logo)} alt="logo" /> : null}


### PR DESCRIPTION
While merging and deploying to staging, it doesn't work right away. There are 2 problems:

1. The getDashboardName() function in LoginOrApp.js does not work properly on staging

2. The routing doesn't navigate us to the correct route.

This PR is to fix the 2 above problems.